### PR TITLE
feature:#18 commons/round-button 컴포넌트 생성 및 기능구현

### DIFF
--- a/src/components/commons/round-button.tsx
+++ b/src/components/commons/round-button.tsx
@@ -39,7 +39,6 @@ type RoundButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
  * @param props - 라운드버튼의 기본 속성
  * @returns - 버튼 컴포넌트
  */
-
 const RoundButton = ({
   size,
   children,

--- a/src/components/commons/round-button.tsx
+++ b/src/components/commons/round-button.tsx
@@ -1,0 +1,66 @@
+import { cva, type VariantProps } from 'class-variance-authority';
+import Image from 'next/image';
+import * as React from 'react';
+import { twMerge } from 'tailwind-merge';
+
+const roundButtonVariants = cva(
+  'flex items-center justify-center border border-gray-400 rounded-full w-12 h-12 relative overflow-hidden',
+  {
+    variants: {
+      size: {
+        xs: 'w-6 h-6 text-xs',
+        sm: 'w-8 h-8 text-sm',
+        md: 'w-10 h-10 text-base',
+        lg: 'w-12 h-12 text-lg',
+        xl: 'w-16 h-16 text-xl',
+        '2xl': 'w-20 h-20 text-2xl',
+        '3xl': 'w-24 h-24 text-3xl',
+        '4xl': 'w-32 h-32 text-4xl',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+    },
+  }
+);
+
+type RoundButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> &
+  VariantProps<typeof roundButtonVariants> & {
+    children?: string;
+    imgSrc?: string;
+    alt?: string;
+  };
+
+/**
+ * 버튼 공통 컴포넌트
+ * @param variant - 라운드버튼의 테마 종류
+ * @param size - 라운드버튼의 크기 종류
+ * @param children - 라운드버튼 안에 들어가는 텍스트,이미지
+ * @param props - 라운드버튼의 기본 속성
+ * @returns - 버튼 컴포넌트
+ */
+
+const RoundButton = ({
+  size,
+  children,
+  imgSrc,
+  alt = '이미지',
+  ...props
+}: RoundButtonProps) => {
+  return (
+    <button className={twMerge(roundButtonVariants({ size }))} {...props}>
+      {imgSrc ? (
+        <Image
+          src={imgSrc}
+          alt={alt as string}
+          className='h-full w-full rounded-full object-contain'
+          fill
+        ></Image>
+      ) : (
+        children?.slice(0, 1)
+      )}
+    </button>
+  );
+};
+
+export default RoundButton;


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #18 

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

라운드버튼의 기본 형식을 작성했습니다.
스타일등의 세부적인 정의는 디자인 시안이 완성되면 작업할 예정입니다

사용방법
props : imgSrc에 값이 들어오면 해당 이미지가 원형테두리 안에 위치하게 됩니다.
            imgSrc가 들어오지 않으면, children에 첫글자가 원형테두리 안에 위치하게 됩니다

---

## 💢 테스트 사항

---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->

---

## 🙏 리뷰어에게 요청사항

없으면 놔두세요.
