### PR TITLE
Feature/#22 floating sheet

### DIFF
--- a/src/components/commons/floating-sheet.tsx
+++ b/src/components/commons/floating-sheet.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import React, { ReactNode, useState } from 'react';
+import useFloatingSheetStore from '@/shared/hooks/use-floating-sheet-store';
+import { ReactNode } from 'react';
 import Draggable, { DraggableData, DraggableEvent } from 'react-draggable';
 
 type FloatingSheetProps = { children: ReactNode };
@@ -11,8 +12,9 @@ type FloatingSheetProps = { children: ReactNode };
  * @returns - 드래그 가능한 플로팅 패널 요소
  */
 const FloatingSheet = ({ children }: FloatingSheetProps) => {
-  // 초기 위치 상태 관리 (선택사항)
-  const [position, setPosition] = useState({ x: 0, y: 0 });
+  const position = useFloatingSheetStore((state) => state.position);
+  const setPosition = useFloatingSheetStore((state) => state.setPosition);
+  const hide = useFloatingSheetStore((state) => state.hide);
 
   // 드래그가 끝났을 때 위치 업데이트
   const handleDragStop = (e: DraggableEvent, data: DraggableData) => {
@@ -24,7 +26,7 @@ const FloatingSheet = ({ children }: FloatingSheetProps) => {
   };
 
   return (
-    <div className='h-dvh w-dvw'>
+    <div className='fixed h-dvh w-dvw' onClick={hide}>
       <Draggable
         handle='.handle' // 드래그 핸들 지정 (선택사항)
         position={position}
@@ -34,16 +36,22 @@ const FloatingSheet = ({ children }: FloatingSheetProps) => {
         onStop={handleDragStop}
         bounds='parent' // 부모 요소 내부로 제한 (선택사항)
       >
-        <div className='fixed z-50 rounded-lg border bg-white p-4 shadow-lg'>
+        <div
+          onClick={(e) => {
+            e.stopPropagation();
+          }}
+          className='fixed z-50 rounded-lg border bg-white p-4 shadow-lg'
+        >
           {/* 드래그 핸들 */}
-          <div className='handle mb-2 flex h-6 cursor-pointer items-center justify-center rounded bg-gray-100'>
-            <div className='h-1 w-10 rounded-full bg-gray-300'></div>
+          <div className='flex justify-end'>
+            <button onClick={hide}>...X...</button>
+          </div>
+          <div className='handle mb-2 flex h-6 cursor-pointer items-center justify-center rounded bg-gray'>
+            <div className='bg-gray-300 h-1 w-10 rounded-full'></div>
           </div>
 
           {/* 시트 안에 들어갈 내용 드래그 중 텍스트 선택 방지 */}
           <div className='select-none'>
-            <h3 className='mb-2 font-bold'>플로팅 패널</h3>
-            <p>이 패널을 드래그하여 이동할 수 있습니다.</p>
             <div>{children}</div>
           </div>
         </div>

--- a/src/shared/hooks/use-floating-sheet-store.ts
+++ b/src/shared/hooks/use-floating-sheet-store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+
+type FloatingSheetState = {
+  // 상태 (데이터)
+  isVisible: boolean; // 온오프 상태
+  position: { x: number; y: number }; // 위치 좌표
+
+  show: () => void; // 시트 보이기
+  hide: () => void; // 시트 숨기기
+  setPosition: (position: { x: number; y: number }) => void; // 위치 설정)
+};
+
+// Zustand 스토어 생성
+const useFloatingSheetStore = create<FloatingSheetState>((set) => ({
+  // 초기 상태
+  isVisible: false,
+  position: { x: 0, y: 0 },
+
+  // 액션 구현
+  show: () => set({ isVisible: true }),
+  hide: () => set({ isVisible: false }),
+  setPosition: (position) => set({ position }),
+}));
+
+export default useFloatingSheetStore;

--- a/src/shared/hooks/use-floating-sheet-store.ts
+++ b/src/shared/hooks/use-floating-sheet-store.ts
@@ -1,7 +1,6 @@
 import { create } from 'zustand';
 
 type FloatingSheetState = {
-  // 상태 (데이터)
   isVisible: boolean; // 온오프 상태
   position: { x: number; y: number }; // 위치 좌표
 
@@ -10,10 +9,10 @@ type FloatingSheetState = {
   setPosition: (position: { x: number; y: number }) => void; // 위치 설정)
 };
 
-// Zustand 스토어 생성
 const useFloatingSheetStore = create<FloatingSheetState>((set) => ({
-  // 초기 상태
+  //화면의 on,off(마운트, 언마운트) 제어 state
   isVisible: false,
+  //floating sheet의 위치를 저장하는 state
   position: { x: 0, y: 0 },
 
   // 액션 구현


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #22 

---

## 📌 작업 내용 요약
-  [ ] floating sheet 사용의 간편성과 유저 편의성(페이지 이동시에도 위치 기억)을 위해 store을 생성하였습니다.
 - [ ]  floating sheet 를 닫는 X 버튼을 만들었습니다. floating sheet 바깥 영역 클릭시 닫힙니다.
<!-- 수행한 작업에 대해 간단히 설명해주세요. -->
## 사용방법 안내

- store에서 isVisible을 가져와 floating sheet의 마운트를 제어합니다.
- store에서 show를 가져와 해당 함수 실행 시 isVisible가 true가 되어 floating sheet를 표시할 수 있습니다.

![플로팅시트사용법](https://github.com/user-attachments/assets/0229c6c9-667c-405c-af74-0cd3a571876b)

---

## 💢 테스트 사항

---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->
## 플로팅 시트 영역 안내
- 회색부분이 드래그 영역입니다.
- ...X... 을 누르면 floating sheet가 사라집니다.
![image](https://github.com/user-attachments/assets/09fbdb6a-2f89-4bb3-8b9a-e4b541b4f3a9)



---

## 🙏 리뷰어에게 요청사항
1. floating sheet가 처음에 어디 뜨는 게 좋을지 디자이너 분과 상의가 필요합니다. 처음 뜰때는 화면 가운데에 뜨는 방향을 생각하고 있습니다.


2. X 버튼에 대한 디자인은 나중에 floating sheet 의 간격이 정확히 정해지면 구현할 예정입니다.


