### PR TITLE
Feature/#65 todo crud

### DIFF
--- a/src/app/mandalart/page.tsx
+++ b/src/app/mandalart/page.tsx
@@ -13,6 +13,8 @@ import useFloatingSheetStore from '@/shared/hooks/use-floating-sheet-store';
 import { getBrowserClient } from '@/shared/utils/supabase/browser-client';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCurrentUserId } from '@/modules/mandalart/hooks/use-current-user-id';
+import { useEffect } from 'react';
+import { createTodoListkey } from '@/modules/mandalart/services/create-todo-list-key';
 
 /**
  * Memo: useCurrentUserName 훅으로 닉네임을 가져와서
@@ -34,7 +36,14 @@ const MandalartPage = () => {
     '6424de9b-7fbf-470a-9743-c9bb5e3cdad8'
   );
 
+  useEffect(() => {
+    if (isPending) return;
+
+    createTodoListkey(queryClient, data);
+  }, [isPending, data, queryClient]);
+
   const broadcastChannel = supabase.channel('broadcastChannel');
+
   useBatchUpdateTrigger();
   broadcastChannel
     .on('broadcast', { event: 'shout' }, (payload) => {

--- a/src/app/mandalart/page.tsx
+++ b/src/app/mandalart/page.tsx
@@ -54,7 +54,6 @@ const MandalartPage = () => {
           queryClient.setQueryData(
             QUERY_KEY.todolist(payload.payload.cell_id),
             (todoList: TodoPayloadType[]) => {
-              console.log(todoList);
               return todoList.map((item) =>
                 item.id === payload.payload.id ? payload.payload : item
               );

--- a/src/modules/mandalart/components/cell.tsx
+++ b/src/modules/mandalart/components/cell.tsx
@@ -1,11 +1,14 @@
 import Button from '@/components/commons/button';
 import useFloatingSheetStore from '@/shared/hooks/use-floating-sheet-store';
 import RegisterTodo from './register-todo';
-import { CellInfoType } from '../types/realtime-type';
+import { CellInfoType, TodoPayloadType } from '../types/realtime-type';
 import React, { useEffect } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { getQueryKey } from '../services/get-data-category';
-import { useCellCacheQuery } from '../hooks/use-mandalart-data-query';
+import {
+  useCellCacheQuery,
+  useTodoListCacheQuery,
+} from '../hooks/use-mandalart-data-query';
 
 type CellProps = {
   value: string;
@@ -22,6 +25,7 @@ type CellProps = {
  */
 const Cell = ({ value, className, info }: CellProps) => {
   const queryClient = useQueryClient();
+
   useEffect(() => {
     // tanstack query key에 셀 정보 저장하는 로직
     queryClient.setQueryData(getQueryKey(info), value);
@@ -32,6 +36,9 @@ const Cell = ({ value, className, info }: CellProps) => {
 
   const show = useFloatingSheetStore((state) => state.show);
   const setInfo = useFloatingSheetStore((state) => state.setInfo);
+
+  const { data: todoList } = useTodoListCacheQuery(info.id);
+  const todoListCacheArray = (todoList ?? []) as TodoPayloadType[];
 
   // 플로팅 시트를 띄우는 이벤트 핸들러
   const handleClick = () => {
@@ -51,7 +58,7 @@ const Cell = ({ value, className, info }: CellProps) => {
       </Button>
       {/* Todo key 등록을 위한 등록 컴포넌트 */}
       {'cell_todos' in info &&
-        info.cell_todos?.map((todo, idx) => {
+        todoListCacheArray.map((todo, idx) => {
           return <RegisterTodo key={idx} todo={todo} />;
         })}
     </>

--- a/src/modules/mandalart/components/mandalart-floating-sheet.tsx
+++ b/src/modules/mandalart/components/mandalart-floating-sheet.tsx
@@ -16,9 +16,13 @@ import SubtopicGroup from './subtopic-group';
 import { RealtimeChannel } from '@supabase/supabase-js';
 import { useBroadcastMutation } from '../hooks/use-broadcast-mutation';
 import { useThrottleMutate } from '../hooks/use-throttle-mutate';
-import { useTodoListCacheQuery } from '../hooks/use-mandalart-data-query';
+import {
+  useCellCacheQuery,
+  useTodoListCacheQuery,
+} from '../hooks/use-mandalart-data-query';
 import { useTodoBroadcastMutation } from '../hooks/use-todo-broadcast-mutation';
 import { createNewTodoRowValue } from '../services/create-new-todo-row-value';
+import RoundButton from '@/components/commons/round-button';
 
 /**
  * Todo floating sheet 컴포넌트
@@ -30,11 +34,15 @@ type FloatingSheetProps = {
 };
 const MandalartFloatingSheet = ({ channelReceiver }: FloatingSheetProps) => {
   // 클릭한 셀의 정보 받아오기
-  const [value, setValue] = useState<string>('');
-
   const info = getDataCategory(
     useFloatingSheetStore((state) => state.info) as CellInfoType
   );
+
+  const [disabled, setDisabled] = useState<boolean>(true);
+
+  const { data: initialValue } = useCellCacheQuery(info);
+
+  const [value, setValue] = useState<string>(initialValue ?? '');
 
   const { data: todoList } = useTodoListCacheQuery(info.id);
   const todoListCacheArray = (todoList ?? []) as TodoPayloadType[];
@@ -50,15 +58,22 @@ const MandalartFloatingSheet = ({ channelReceiver }: FloatingSheetProps) => {
   return (
     <FloatingSheet>
       <div className='space-y-4 p-4'>
-        <Input
-          type='text'
-          value={value}
-          onChange={(e) => {
-            setValue(e.target.value);
-            throttleMutate();
-          }}
-          placeholder={info.content || info.title || info.topic || ''}
-        />
+        <div className='flex items-center gap-2'>
+          <Input
+            variant={disabled ? 'none' : 'default'}
+            type='text'
+            value={value}
+            placeholder={value}
+            onChange={(e) => {
+              setValue(e.target.value);
+              throttleMutate();
+            }}
+            disabled={disabled}
+          />
+          <RoundButton size='xs' onClick={() => setDisabled(!disabled)}>
+            편
+          </RoundButton>
+        </div>
         {/* 핵심주제일 경우 */}
         {info.category === 'CORE' && (
           <div>

--- a/src/modules/mandalart/components/mandalart-floating-sheet.tsx
+++ b/src/modules/mandalart/components/mandalart-floating-sheet.tsx
@@ -64,7 +64,11 @@ const MandalartFloatingSheet = ({ channelReceiver }: FloatingSheetProps) => {
           <div>
             <Text>대주제</Text>
             {info.mandalart_topics?.map((topic) => (
-              <TopicGroup key={topic.id} topic={topic} />
+              <TopicGroup
+                key={topic.id}
+                topic={topic}
+                channelReceiver={channelReceiver}
+              />
             ))}
           </div>
         )}
@@ -73,7 +77,11 @@ const MandalartFloatingSheet = ({ channelReceiver }: FloatingSheetProps) => {
           <div>
             <Text>소주제</Text>
             {info.mandalart_subtopics?.map((sub) => (
-              <SubtopicGroup key={sub.id} sub={sub} />
+              <SubtopicGroup
+                key={sub.id}
+                sub={sub}
+                channelReceiver={channelReceiver}
+              />
             ))}
           </div>
         )}

--- a/src/modules/mandalart/components/register-todo.tsx
+++ b/src/modules/mandalart/components/register-todo.tsx
@@ -11,7 +11,7 @@ type TodoProps = {
  * @returns
  */
 const RegisterTodo = ({ todo }: TodoProps) => {
-  useTodoDataQuery(todo.title ?? '', todo.id);
+  useTodoDataQuery(todo ?? '', todo.id);
   return null;
 };
 

--- a/src/modules/mandalart/components/subtopic-group.tsx
+++ b/src/modules/mandalart/components/subtopic-group.tsx
@@ -1,18 +1,25 @@
 import TodoItem from './todo-item';
 import { SubTopicType, TodoType } from '../types/realtime-type';
 import { useSubtopicCacheQuery } from '../hooks/use-mandalart-data-query';
+import { RealtimeChannel } from '@supabase/supabase-js';
 
 type SubtopicGroupProps = {
   sub: SubTopicType;
+  channelReceiver: RealtimeChannel;
 };
 
-const SubtopicGroup = ({ sub }: SubtopicGroupProps) => {
+const SubtopicGroup = ({ sub, channelReceiver }: SubtopicGroupProps) => {
   const { data: subtopicName } = useSubtopicCacheQuery(sub.id);
   return (
     <div className='pl-4'>
       <div>{subtopicName}</div>
       {sub.cell_todos?.map((todo: TodoType) => (
-        <TodoItem key={todo.id} id={todo.id} />
+        <TodoItem
+          key={todo.id}
+          id={todo.id}
+          cellId={todo}
+          channelReceiver={channelReceiver}
+        />
       ))}
     </div>
   );

--- a/src/modules/mandalart/components/subtopic-group.tsx
+++ b/src/modules/mandalart/components/subtopic-group.tsx
@@ -1,6 +1,13 @@
 import TodoItem from './todo-item';
-import { SubTopicType, TodoType } from '../types/realtime-type';
-import { useSubtopicCacheQuery } from '../hooks/use-mandalart-data-query';
+import {
+  SubTopicType,
+  TodoPayloadType,
+  TodoType,
+} from '../types/realtime-type';
+import {
+  useSubtopicCacheQuery,
+  useTodoListCacheQuery,
+} from '../hooks/use-mandalart-data-query';
 import { RealtimeChannel } from '@supabase/supabase-js';
 
 type SubtopicGroupProps = {
@@ -10,10 +17,13 @@ type SubtopicGroupProps = {
 
 const SubtopicGroup = ({ sub, channelReceiver }: SubtopicGroupProps) => {
   const { data: subtopicName } = useSubtopicCacheQuery(sub.id);
+
+  const { data: todoList } = useTodoListCacheQuery(sub.id);
+  const todoListCacheArray = (todoList ?? []) as TodoPayloadType[];
   return (
     <div className='pl-4'>
       <div>{subtopicName}</div>
-      {sub.cell_todos?.map((todo: TodoType) => (
+      {todoListCacheArray.map((todo: TodoType) => (
         <TodoItem
           key={todo.id}
           id={todo.id}

--- a/src/modules/mandalart/components/todo-item.tsx
+++ b/src/modules/mandalart/components/todo-item.tsx
@@ -18,14 +18,23 @@ type TodoItemProps = {
 
 const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
   const queryClient = useQueryClient();
+  const [valuePayload, setValuePayload] = useState<string>('');
 
   const { data: todo } = useTodoCacheQuery(id);
   const todoRow = (todo ?? {}) as TodoPayloadType;
 
   const getInitialValue = () => todoRow.value || todoRow.title || '';
   const [value, setValue] = useState<string>(getInitialValue());
+  const memoValue = useMemo(
+    () => setValuePayload(todoRow.value),
+    [todoRow.value]
+  );
 
   const [done, setDone] = useState<boolean>(todoRow.is_done ?? false);
+  const memoIsDone = useMemo(
+    () => setDone(todoRow.is_done ?? false),
+    [todoRow.is_done]
+  );
 
   const { mutate } = useTodoBroadcastMutation(
     channelReceiver,
@@ -60,7 +69,7 @@ const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
         }}
       />
       <Input
-        value={value}
+        value={valuePayload || value}
         placeholder='TODO를 작성해주세요.'
         onChange={(e) => {
           const newValue = e.target.value;

--- a/src/modules/mandalart/components/todo-item.tsx
+++ b/src/modules/mandalart/components/todo-item.tsx
@@ -19,6 +19,7 @@ type TodoItemProps = {
 const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
   const queryClient = useQueryClient();
   const [valuePayload, setValuePayload] = useState<string>('');
+  const [disabled, setDisabled] = useState<boolean>(true);
 
   const { data: todo } = useTodoCacheQuery(id);
   const todoRow = (todo ?? {}) as TodoPayloadType;
@@ -69,6 +70,7 @@ const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
         }}
       />
       <Input
+        variant={disabled ? 'none' : 'default'}
         value={valuePayload || value}
         placeholder='TODO를 작성해주세요.'
         onChange={(e) => {
@@ -91,6 +93,7 @@ const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
           );
           throttledMutate();
         }}
+        disabled={disabled}
       />
       <RoundButton
         size='xs'
@@ -106,6 +109,9 @@ const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
         }}
       >
         X
+      </RoundButton>
+      <RoundButton size='xs' onClick={() => setDisabled(!disabled)}>
+        편
       </RoundButton>
     </div>
   );

--- a/src/modules/mandalart/components/todo-item.tsx
+++ b/src/modules/mandalart/components/todo-item.tsx
@@ -1,16 +1,103 @@
 import CheckBox from '@/components/commons/check-box';
 import { useTodoCacheQuery } from '../hooks/use-mandalart-data-query';
+import { useMemo, useState } from 'react';
+import { TodoPayloadType, TodoType } from '../types/realtime-type';
+import { useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/shared/constants/query-key';
+import Input from '@/components/commons/input';
+import RoundButton from '@/components/commons/round-button';
+import { RealtimeChannel } from '@supabase/supabase-js';
+import { useTodoBroadcastMutation } from '../hooks/use-todo-broadcast-mutation';
+import { throttleMutate } from '../services/throttle-mutate';
 
 type TodoItemProps = {
   id: string;
+  cellId: TodoType;
+  channelReceiver: RealtimeChannel;
 };
 
-const TodoItem = ({ id }: TodoItemProps) => {
+const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
+  const queryClient = useQueryClient();
+
   const { data: todo } = useTodoCacheQuery(id);
+  const todoRow = (todo ?? {}) as TodoPayloadType;
+
+  const getInitialValue = () => todoRow.value || todoRow.title || '';
+  const [value, setValue] = useState<string>(getInitialValue());
+
+  const [done, setDone] = useState<boolean>(todoRow.is_done ?? false);
+
+  const { mutate } = useTodoBroadcastMutation(
+    channelReceiver,
+    cellId as TodoPayloadType
+  );
+  const throttledMutate = useMemo(() => throttleMutate(mutate, 300), [mutate]);
+  const deleteMutate = useMemo(() => throttleMutate(mutate, 50), [mutate]);
+
   return (
     <div className='flex items-center'>
-      <CheckBox />
-      <div className='ml-2'>{todo}</div>
+      <CheckBox
+        checked={done}
+        onChange={() => {
+          const newDone = done;
+          setDone(!newDone);
+          queryClient.setQueryData(
+            QUERY_KEY.todo(id),
+            (entry: TodoPayloadType) => {
+              queryClient.setQueryData(
+                QUERY_KEY.todolist(cellId.cell_id),
+                (todoList: TodoPayloadType[]) =>
+                  todoList.map((todo) =>
+                    todo.id === id
+                      ? { ...todo, is_done: !newDone, action: 'UPDATE' }
+                      : todo
+                  )
+              );
+              return { ...entry, is_done: !newDone };
+            }
+          );
+          throttledMutate();
+        }}
+      />
+      <Input
+        value={value}
+        placeholder='TODO를 작성해주세요.'
+        onChange={(e) => {
+          const newValue = e.target.value;
+          setValue(newValue);
+          queryClient.setQueryData(
+            QUERY_KEY.todo(id),
+            (entry: TodoPayloadType) => {
+              queryClient.setQueryData(
+                QUERY_KEY.todolist(cellId.cell_id),
+                (todoList: TodoPayloadType[]) =>
+                  todoList.map((todo) =>
+                    todo.id === id
+                      ? { ...todo, action: 'UPDATE', value: newValue }
+                      : todo
+                  )
+              );
+              return { ...entry, action: 'UPDATE', value: newValue };
+            }
+          );
+          throttledMutate();
+        }}
+      />
+      <RoundButton
+        size='xs'
+        onClick={() => {
+          queryClient.setQueryData(
+            QUERY_KEY.todolist(cellId.cell_id),
+            (todoList: TodoPayloadType[]) =>
+              todoList.map((todo) =>
+                todo.id === id ? { ...todo, action: 'DELETE' } : todo
+              )
+          );
+          deleteMutate();
+        }}
+      >
+        X
+      </RoundButton>
     </div>
   );
 };

--- a/src/modules/mandalart/components/todo-item.tsx
+++ b/src/modules/mandalart/components/todo-item.tsx
@@ -8,7 +8,7 @@ import Input from '@/components/commons/input';
 import RoundButton from '@/components/commons/round-button';
 import { RealtimeChannel } from '@supabase/supabase-js';
 import { useTodoBroadcastMutation } from '../hooks/use-todo-broadcast-mutation';
-import { throttleMutate } from '../services/throttle-mutate';
+import { useThrottleMutate } from '../hooks/use-throttle-mutate';
 
 type TodoItemProps = {
   id: string;
@@ -40,8 +40,8 @@ const TodoItem = ({ id, cellId, channelReceiver }: TodoItemProps) => {
     channelReceiver,
     cellId as TodoPayloadType
   );
-  const throttledMutate = useMemo(() => throttleMutate(mutate, 300), [mutate]);
-  const deleteMutate = useMemo(() => throttleMutate(mutate, 50), [mutate]);
+  const throttledMutate = useThrottleMutate(mutate, 300);
+  const deleteMutate = useThrottleMutate(mutate, 50);
 
   return (
     <div className='flex items-center'>

--- a/src/modules/mandalart/components/topic-group.tsx
+++ b/src/modules/mandalart/components/topic-group.tsx
@@ -2,19 +2,25 @@ import Text from '@/components/commons/text';
 import { TopicType } from '../types/realtime-type';
 import SubtopicGroup from './subtopic-group';
 import { useTopicCacheQuery } from '../hooks/use-mandalart-data-query';
+import { RealtimeChannel } from '@supabase/supabase-js';
 
 type TopicGroupProps = {
   topic: TopicType;
+  channelReceiver: RealtimeChannel;
 };
 
-const TopicGroup = ({ topic }: TopicGroupProps) => {
+const TopicGroup = ({ topic, channelReceiver }: TopicGroupProps) => {
   const { data: topicName } = useTopicCacheQuery(topic.id);
   return (
     <div className='pl-2'>
       <div className='text-blue-700'>{topicName}</div>
       <Text>소주제</Text>
       {topic.mandalart_subtopics?.map((sub) => (
-        <SubtopicGroup key={sub.id} sub={sub} />
+        <SubtopicGroup
+          key={sub.id}
+          sub={sub}
+          channelReceiver={channelReceiver}
+        />
       ))}
     </div>
   );

--- a/src/modules/mandalart/hooks/use-mandalart-data-query.ts
+++ b/src/modules/mandalart/hooks/use-mandalart-data-query.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchGetMandalartsData } from '../services/fetch-get-mandalarts-data';
-import { CellInfoType, MandalartType } from '../types/realtime-type';
+import { CellInfoType, MandalartType, TodoType } from '../types/realtime-type';
 import { QUERY_KEY } from '@/shared/constants/query-key';
 import { getQueryKey } from '../services/get-data-category';
 
@@ -24,7 +24,7 @@ export const useMandalartDataQuery = (id: string) => {
  * @param id - todo id
  * @returns
  */
-export const useTodoDataQuery = (value: string, id: string) => {
+export const useTodoDataQuery = (value: TodoType, id: string) => {
   return useQuery({
     queryKey: QUERY_KEY.todo(id),
     queryFn: () => Promise.resolve(value),
@@ -43,6 +43,21 @@ export const useTodoCacheQuery = (id: string) => {
     queryKey: QUERY_KEY.todo(id),
     queryFn: () => Promise.resolve(null),
     enabled: false,
+  });
+};
+
+/**
+ * 투두 리스트(cell_todos 컬럼)를 useQuery에 저장하는 훅
+ * @param id - 가져올 cell값
+ * @returns
+ */
+export const useTodoListCacheQuery = (id: string) => {
+  return useQuery({
+    queryKey: QUERY_KEY.todolist(id),
+    queryFn: () => Promise.resolve(null),
+    enabled: false,
+    staleTime: Infinity,
+    gcTime: Infinity,
   });
 };
 

--- a/src/modules/mandalart/hooks/use-todo-broadcast-mutation.ts
+++ b/src/modules/mandalart/hooks/use-todo-broadcast-mutation.ts
@@ -1,0 +1,36 @@
+import { RealtimeChannel } from '@supabase/supabase-js';
+import { TodoPayloadType } from '../types/realtime-type';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { QUERY_KEY } from '@/shared/constants/query-key';
+import { judgingAction } from '../services/judging-action';
+
+export const useTodoBroadcastMutation = (
+  myChannel: RealtimeChannel,
+  todoRowData: TodoPayloadType
+) => {
+  const queryClient = useQueryClient();
+
+  const todoListKey: readonly unknown[] = QUERY_KEY.todolist(
+    todoRowData.cell_id
+  );
+
+  const mutationUpdateCache = useMutation({
+    onMutate: async () => judgingAction(queryClient, todoListKey, todoRowData),
+    mutationFn: async () => {
+      if (!myChannel) throw new Error('채널없음');
+      await myChannel.send({
+        type: 'broadcast',
+        event: 'shout',
+        payload: todoRowData,
+      });
+    },
+    onError: () => {
+      /**
+       * TODO: error 핸들링 sentry 리팩터링
+       */
+      console.error('broadcast에 오류가 발생했습니다.');
+    },
+  });
+
+  return { ...mutationUpdateCache };
+};

--- a/src/modules/mandalart/services/create-new-todo-row-value.ts
+++ b/src/modules/mandalart/services/create-new-todo-row-value.ts
@@ -1,0 +1,14 @@
+import { TodoPayloadType } from '../types/realtime-type';
+
+export const createNewTodoRowValue = (subtopicId: string): TodoPayloadType => {
+  return {
+    id: crypto.randomUUID(),
+    cell_id: subtopicId,
+    created_at: new Date().toISOString(),
+    is_done: false,
+    title: '새 TODO',
+    action: 'CREATE',
+    value: '새 TODO',
+    category: 'TODO',
+  };
+};

--- a/src/modules/mandalart/services/create-todo-list-key.ts
+++ b/src/modules/mandalart/services/create-todo-list-key.ts
@@ -1,0 +1,19 @@
+import { QueryClient } from '@tanstack/react-query';
+import { MandalartType } from '../types/realtime-type';
+import { QUERY_KEY } from '@/shared/constants/query-key';
+
+export const createTodoListkey = (
+  queryClient: QueryClient,
+  dbTableJoinData: MandalartType | undefined
+) => {
+  if (!dbTableJoinData) return;
+
+  return dbTableJoinData.mandalart_topics.map((topic) => {
+    topic.mandalart_subtopics.map((subtopic) => {
+      queryClient.setQueryData(
+        QUERY_KEY.todolist(subtopic.id),
+        subtopic.cell_todos
+      );
+    });
+  });
+};

--- a/src/modules/mandalart/services/judging-action.ts
+++ b/src/modules/mandalart/services/judging-action.ts
@@ -1,0 +1,31 @@
+import { QueryClient } from '@tanstack/react-query';
+import { TodoPayloadType } from '../types/realtime-type';
+
+export const judgingAction = (
+  queryClient: QueryClient,
+  key: readonly unknown[],
+  todoRowValue: TodoPayloadType
+) => {
+  if (todoRowValue.action === 'UPDATE') {
+    queryClient.setQueryData(key, (prev: TodoPayloadType[]) => {
+      return prev.map((item) =>
+        item.id === todoRowValue.id ? todoRowValue : item
+      );
+    });
+    return;
+  }
+
+  if (todoRowValue.action === 'CREATE') {
+    queryClient.setQueryData(key, (prev: TodoPayloadType[]) => {
+      return [...prev, todoRowValue];
+    });
+    return;
+  }
+
+  if (todoRowValue.action === 'DELETE') {
+    queryClient.setQueryData(key, (prev: TodoPayloadType[]) => {
+      return prev.filter((item) => item.id !== todoRowValue.id);
+    });
+    return;
+  }
+};

--- a/src/shared/constants/query-key.ts
+++ b/src/shared/constants/query-key.ts
@@ -3,4 +3,5 @@ export const QUERY_KEY = {
   topic: (id: string): ['TOPIC', string] => ['TOPIC', id],
   subtopic: (id: string): ['SUBTOPIC', string] => ['SUBTOPIC', id],
   todo: (id: string): ['TODO', string] => ['TODO', id],
+  todolist: (id: string): ['TODOLIST', string] => ['TODOLIST', id],
 };


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #65 #45

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

- [x] 플로팅 시트 내부의 todo가 잘 생성됨
- [x] 플로팅 시트 내부의 todo가 잘 수정됨
- [x] 플로팅 시트 내부의 todo가 잘 삭제됨
- [x] 플로팅 시트에서 표현되는 값들의 초기값 / 수정값의 구분을 통해 상태를 관리
- [x] 새로운 id의 객체가 클라이언트부터 생성됨
- [x] 소주제 / 대주제 / 핵심주제 cell의 하위 todo 수정 / 삭제 가능
- [x] todo 추가는 소주제 cell의 플로팅 시트에서만 가능 

---

## 💢 테스트 사항
- [x] todo 수정, 삭제, 추가 및 행동에 따른 리렌더링 확인
- [x] 플로팅 시트를 껐다 켜도 수정된 값으로 잘 유지됨을 확인
- [x] supabase.send() 메서드에 action 값 포함하여 잘 넘어가는걸 확인
- [x] tanstackQuery devtools를 사용해서 필요한 cache값이 잘 바뀜을 확인(todo 내부 cache값과 todolist 내부의 cache값 확인)

---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->
<img width="542" alt="스크린샷 2025-04-13 오전 4 22 53" src="https://github.com/user-attachments/assets/85f3d4cc-6c13-451b-a29c-01ca96bca5a3" />
<img width="542" alt="스크린샷 2025-04-13 오전 4 23 12" src="https://github.com/user-attachments/assets/e5e275b2-3447-4707-a519-0e798fa1ece9" />
<img width="542" alt="스크린샷 2025-04-13 오전 4 23 45" src="https://github.com/user-attachments/assets/f06ad520-5c42-4301-aa58-0845e5c8e2a5" />


---

## 🙏 리뷰어에게 요청사항

useQuery에서 넘어오는 값이 null | undefined가 대부분이라 ?? 연산자 써서 처리해두고...
setQueryData에서 두 번째 인자를 콜백함수 써서 tanstackQuery cache 값 map,filter해서 직접 수정하고...
새로운 TODOLIST라는 key 종류를 만들어 상태가 64개가 더 생겼는데 이거 비둘기 머리 돌리는거 같나요...?

그리고 채널의 경우는 전역에서 관리할까 싶었는데 이것도 타입에 null이 한 자리를 꿰차길래 props로 내려버렸습니다..
물론 2번 정도의 drilling은 일어났지만... prop drilling은 나쁜게 아니니...!! 어떻게 하면 좋을지 이야기 해봐야 할 것 같습니다!

그리고 setQueryData가 중첩되다보니 mutate보다 늦게 작동되어 action이 안들어가는 문제가 발생하였기에 쓰로틀링으로 임시방편 해두었습니다. 근데 ux 측에선 별로 티가 안나네요.. 이것도 관련해서 이야기하시져!