### PR TITLE
feature:#192 피드백 수용

### DIFF
--- a/src/modules/dashboard/components/card-button-drop-down.tsx
+++ b/src/modules/dashboard/components/card-button-drop-down.tsx
@@ -389,6 +389,13 @@ const UpdateDateModal = ({
     ) {
       return infoAlert('날짜의 변화가 없는데요?');
     }
+    if (
+      selectedDate.endYear === '' ||
+      selectedDate.endMonth === '' ||
+      selectedDate.endDay === ''
+    ) {
+      return infoAlert('날짜를 모두 선택해주세요.');
+    }
     updateDate({
       mandalartId: mandalartId,
       endDate: `${selectedDate.endYear}-${selectedDate.endMonth}-${selectedDate.endDay}`,

--- a/src/modules/dashboard/components/category-board.tsx
+++ b/src/modules/dashboard/components/category-board.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils';
 import MandalartCard from './mandalart-card';
 import Spacer from '@/components/commons/spacer';
 import Text from '@/components/commons/text';
-import { getColorWithIndexOrder } from '@/shared/utils/get-color-with-index';
+import { getColorWithIndexOrderPigment } from '@/shared/utils/get-color-with-index';
 import { useGetMandalartCards } from '../hooks/use-get-mandalart-cards';
 import { FetchUserRoomsAndParticipantsResponse } from '@/modules/dashboard/types/dashboard-type';
 
@@ -76,7 +76,7 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className='animate-fade-out-left h-[280px] w-full max-w-[360px] rounded-lg bg-lightgray shadow-[0px_0px_12px_0px_rgba(0,_0,_0,_0.1)]'
+              className='h-[280px] w-full max-w-[360px] animate-fade-out-left rounded-lg bg-lightgray shadow-[0px_0px_12px_0px_rgba(0,_0,_0,_0.1)]'
             />
           ))}
         </div>
@@ -109,13 +109,13 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
       {category === '진행 중인 목표' ? (
         <div className='flex'>
           {yetMandalart && yetMandalart?.length ? (
-            <div className='animate-fade-in-left grid w-[1252px] grid-cols-1 place-items-center gap-[40px] md:grid-cols-2 lg:grid-cols-3'>
+            <div className='grid w-[1252px] animate-fade-in-left grid-cols-1 place-items-center gap-[40px] md:grid-cols-2 lg:grid-cols-3'>
               {yetMandalart.map(
                 (
                   card: FetchUserRoomsAndParticipantsResponse,
                   index: number
                 ) => {
-                  const bandColor = getColorWithIndexOrder(
+                  const bandColor = getColorWithIndexOrderPigment(
                     card.mandalart.color || index
                   );
 
@@ -143,13 +143,13 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
       ) : (
         <div className='flex'>
           {doneMandalart && doneMandalart?.length ? (
-            <div className='animate-fade-in-left grid w-full max-w-[1252px] grid-cols-1 place-items-center gap-14 md:grid-cols-2 lg:grid-cols-3'>
+            <div className='grid w-full max-w-[1252px] animate-fade-in-left grid-cols-1 place-items-center gap-14 md:grid-cols-2 lg:grid-cols-3'>
               {doneMandalart.map(
                 (
                   card: FetchUserRoomsAndParticipantsResponse,
                   index: number
                 ) => {
-                  const bandColor = getColorWithIndexOrder(
+                  const bandColor = getColorWithIndexOrderPigment(
                     card.mandalart.color || index
                   );
                   return (

--- a/src/modules/dashboard/components/category-board.tsx
+++ b/src/modules/dashboard/components/category-board.tsx
@@ -76,7 +76,7 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
           {Array.from({ length: 6 }).map((_, i) => (
             <div
               key={i}
-              className='h-[280px] w-full max-w-[360px] animate-fade-out-left rounded-lg bg-lightgray shadow-[0px_0px_12px_0px_rgba(0,_0,_0,_0.1)]'
+              className='animate-fade-out-left h-[280px] w-full max-w-[360px] rounded-lg bg-lightgray shadow-[0px_0px_12px_0px_rgba(0,_0,_0,_0.1)]'
             />
           ))}
         </div>
@@ -109,7 +109,7 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
       {category === '진행 중인 목표' ? (
         <div className='flex'>
           {yetMandalart && yetMandalart?.length ? (
-            <div className='grid w-[1252px] animate-fade-in-left grid-cols-1 place-items-center gap-[40px] md:grid-cols-2 lg:grid-cols-3'>
+            <div className='animate-fade-in-left grid w-[1252px] grid-cols-1 place-items-center gap-[40px] md:grid-cols-2 lg:grid-cols-3'>
               {yetMandalart.map(
                 (
                   card: FetchUserRoomsAndParticipantsResponse,
@@ -134,7 +134,8 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
           ) : (
             <div className='flex w-full justify-center'>
               <Text size='18px-medium' textColor='caption'>
-                아직은 비어 있지만, 곧 채워질 당신의 여정을 기대할게요 :)
+                현재 진행 중인 목표가 없어요. ‘새 만다라트’ 버튼을 눌러 지금
+                바로 시작해보세요!
               </Text>
             </div>
           )}
@@ -142,7 +143,7 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
       ) : (
         <div className='flex'>
           {doneMandalart && doneMandalart?.length ? (
-            <div className='grid w-full max-w-[1252px] animate-fade-in-left grid-cols-1 place-items-center gap-14 md:grid-cols-2 lg:grid-cols-3'>
+            <div className='animate-fade-in-left grid w-full max-w-[1252px] grid-cols-1 place-items-center gap-14 md:grid-cols-2 lg:grid-cols-3'>
               {doneMandalart.map(
                 (
                   card: FetchUserRoomsAndParticipantsResponse,
@@ -166,8 +167,7 @@ export const CategoryBoard = ({ user }: CategoryBoardProps) => {
           ) : (
             <div className='flex w-full justify-center'>
               <Text size='18px-medium' textColor='caption'>
-                현재 진행 중인 목표가 없어요. ‘새 만다라트’ 버튼을 눌러 지금
-                바로 시작해보세요!
+                아직은 비어 있지만, 곧 채워질 당신의 여정을 기대할게요 :)
               </Text>
             </div>
           )}

--- a/src/modules/dashboard/components/create-mandalart-modal.tsx
+++ b/src/modules/dashboard/components/create-mandalart-modal.tsx
@@ -8,7 +8,7 @@ import CalendarDropDown from './calendar-drop-down';
 import { useRef, useState } from 'react';
 import { useMandalartForm } from '../hooks/use-mandalart-form';
 import { useMandalartCreator } from '../hooks/use-mandalart-creator';
-import { getPastelCodeWithIndex } from '@/shared/utils/get-color-with-index';
+import { getPigmentCodeWithIndex } from '@/shared/utils/get-color-with-index';
 import ModalPortal from '@/components/commons/modal-portal';
 
 const CreateMandalartModal = ({
@@ -69,7 +69,7 @@ const CreateMandalartModal = ({
           <div
             className='relative h-[357px] w-full max-w-sm rounded-br-lg rounded-tr-lg border-l-[10px] bg-white shadow-lg outline-red-pastel sm:h-[380px] sm:max-w-[535px] md:h-[408px]'
             onClick={(e) => e.stopPropagation()}
-            style={{ borderColor: getPastelCodeWithIndex(selectedColor) }}
+            style={{ borderColor: getPigmentCodeWithIndex(selectedColor) }}
           >
             <div
               onClick={handleClose}
@@ -102,7 +102,7 @@ const CreateMandalartModal = ({
                   >
                     <Text size='20px-medium' textColor='caption'>
                       {Object.values(date).every((v) => v !== '')
-                        ? `${date.startYear}.${date.startMonth}.${date.startDay} ~ ${date.endYear}.${date.endMonth}.${date.endDay}`
+                        ? `${date.startYear}.${date.startMonth.padStart(2, '0')}.${date.startDay.padStart(2, '0')} ~ ${date.endYear}.${date.endMonth.padStart(2, '0')}.${date.endDay.padStart(2, '0')}`
                         : '기간 설정'}
                     </Text>
                   </div>

--- a/src/modules/dashboard/components/dashboard.tsx
+++ b/src/modules/dashboard/components/dashboard.tsx
@@ -29,9 +29,10 @@ const DashBoard = ({ user }: { user: string | null }) => {
               <Button
                 variant='secondary'
                 size='medium'
+                disabled={isCreateModalOpen}
                 onClick={() => setIsCreateModalOpen(true)}
               >
-                + 새 만다라트
+                <SquarePlus size={24} /> 새 만다라트
               </Button>
             </div>
           </div>

--- a/src/modules/dashboard/util/calculate-date.ts
+++ b/src/modules/dashboard/util/calculate-date.ts
@@ -17,7 +17,7 @@ export const getDateDiff = (endStr: Date): number => {
 
   const diffTime = end.getTime() - now.getTime();
   const diffDays = diffTime / (1000 * 60 * 60 * 24);
-  return diffDays;
+  return Math.ceil(diffDays);
 };
 
 export const getDateToString = (

--- a/src/modules/dashboard/util/format-date.ts
+++ b/src/modules/dashboard/util/format-date.ts
@@ -1,5 +1,5 @@
 export const formatDate = (date: Date): string => {
   const str = date.toString();
-  const [year, month, day] = str.split('-').map(Number);
-  return `${year}.${month}.${day}`;
+  const [year, month, day] = str.split('-').map(String);
+  return `${year}.${month.padStart(2, '0')}.${day.padStart(2, '0')}`;
 };

--- a/src/shared/utils/get-color-with-index.ts
+++ b/src/shared/utils/get-color-with-index.ts
@@ -39,11 +39,32 @@ export const getPastelCodeWithIndex = (index: number): string => {
 };
 
 /**
- * 색상 인덱스에 따라 tailwind 형식으로 반환하는 함수
+ * 인덱스에 따라 Pastel tailwind 형식으로 반환하는 함수
  * @param index - 색상 인덱스
  * @returns - tailwind 속성
  */
 export const getColorWithIndexOrder = (index: number): string => {
+  const idx = index % 8;
+  const color: Record<number, string> = {
+    0: 'bg-pink-pastel',
+    1: 'bg-red-pastel',
+    2: 'bg-orange-pastel',
+    3: 'bg-yellow-pastel',
+    4: 'bg-green-pastel',
+    5: 'bg-sky-pastel',
+    6: 'bg-blue-pastel',
+    7: 'bg-purple-pastel',
+  };
+
+  return color[idx];
+};
+
+/**
+ * 인덱스에 따라 Pigment tailwind 형식으로 반환하는 함수
+ * @param index - 색상 인덱스
+ * @returns - tailwind 속성
+ */
+export const getColorWithIndexOrderPigment = (index: number): string => {
   const idx = index % 8;
   const color: Record<number, string> = {
     0: 'bg-pink-pigment',

--- a/src/shared/utils/get-color-with-index.ts
+++ b/src/shared/utils/get-color-with-index.ts
@@ -46,14 +46,14 @@ export const getPastelCodeWithIndex = (index: number): string => {
 export const getColorWithIndexOrder = (index: number): string => {
   const idx = index % 8;
   const color: Record<number, string> = {
-    0: 'bg-pink-pastel',
-    1: 'bg-red-pastel',
-    2: 'bg-orange-pastel',
-    3: 'bg-yellow-pastel',
-    4: 'bg-green-pastel',
-    5: 'bg-sky-pastel',
-    6: 'bg-blue-pastel',
-    7: 'bg-purple-pastel',
+    0: 'bg-pink-pigment',
+    1: 'bg-red-pigment',
+    2: 'bg-orange-pigment',
+    3: 'bg-yellow-pigment',
+    4: 'bg-green-pigment',
+    5: 'bg-sky-pigment',
+    6: 'bg-blue-pigment',
+    7: 'bg-purple-pigment',
   };
 
   return color[idx];


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #192

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

- [x] 날짜 변경 에러 핸들링 (선택 안하고 확인 누르면 통신 에러 뜨는 알람 수정)
- [x] 변경 날짜에 빈 공백이 들어가면 프론트에서 에러 처리
- [x] 날짜, 컬러 변경 버튼 로딩 disable처리
- [x] 필요사항 버튼의 글씨로 파악 가능 ex) 변경 사항 부재, 잘못된 값  파악
- [x] 날짜의 month와 day부분 남는 공간 0으로 채움 ex) 2024.01.01
- [x] 카드 색상 pastel -> pigment

---

## 💢 테스트 사항
![image](https://github.com/user-attachments/assets/172f52ab-b6a6-451f-89db-bdb4342dccc6)
![image](https://github.com/user-attachments/assets/18e2ec9a-bfda-4a26-beb9-0c39ed757a31)


---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->
테스트 사항의 사진을 봐주세요...

---

## 🙏 리뷰어에게 요청사항

없으면 놔두세요.
