### PR TITLE
Feature/#218 custom alert

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import TQProvider from '@/providers/tq-provider';
 import Footer from '@/components/layouts/footer';
 import Header from '@/components/layouts/header';
 import { getUserInfo } from '@/modules/auth/services/auth-server-service';
+import { Alert } from '@/components/commons/alert';
 
 export const metadata: Metadata = {
   title: '모람모람',
@@ -40,6 +41,7 @@ export default async function RootLayout({
 
         <main className='mt-[72px] flex-grow lg:mt-[100px]'>
           <div className='flex flex-1 items-center justify-center'>
+            <Alert />
             {/* children에 메인 영역이 위치합니다. 중앙 70%의 영역만 차지합니다 */}
             <div className='h-full w-full'>
               <TQProvider>{children}</TQProvider>

--- a/src/components/commons/alert.tsx
+++ b/src/components/commons/alert.tsx
@@ -3,20 +3,38 @@
 import { useAlertStore } from '@/shared/hooks/use-alert-store';
 import Image from 'next/image';
 import Button from './button';
+import Title from './title';
+import Text from './text';
+import { CircleAlert, CircleCheckBig, CircleX, Info } from 'lucide-react';
 
 export const Alert = () => {
-  const { isOpen, type, title, message, onConfirm, onCancel, closeAlert } =
-    useAlertStore();
+  const {
+    isOpen,
+    type,
+    title,
+    message,
+    promiseResolve,
+    closeAlert,
+    isLoading,
+    loadingStart,
+  } = useAlertStore();
 
   if (!isOpen) return null;
 
-  const handleConfirm = () => {
-    onConfirm?.();
+  const handleConfirm = async () => {
+    if (isLoading) {
+      return;
+    }
+    loadingStart();
+    promiseResolve?.(true);
     closeAlert();
   };
 
-  const handleCancel = () => {
-    onCancel?.();
+  const handleCancel = async () => {
+    if (isLoading) {
+      return;
+    }
+    promiseResolve?.(false);
     closeAlert();
   };
 
@@ -28,23 +46,88 @@ export const Alert = () => {
       }}
       className='z-100 fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.6)]'
     >
-      <div className='flex -translate-y-16 flex-col items-center justify-center'>
-        <Image
-          src='/images/progress/30.png'
-          alt='alert'
-          width={100}
-          height={100}
-          className='h-30 w-32'
-        />
-        <div className='w-80 rounded-lg bg-white p-6 shadow-lg'>
-          <h2 className='mb-2 text-xl font-bold'>{title}</h2>
-          <p className='text-gray-600 mb-4'>{message}</p>
+      <div className='flex -translate-y-8 flex-col items-center justify-center transition-transform'>
+        <div className='animate-fade-in-top'>
+          {type === 'confirm' && (
+            <Image
+              src='/images/progress/60.png'
+              alt='confirmAlert'
+              width={100}
+              height={100}
+              className='h-12 w-16'
+              draggable={false}
+            />
+          )}
+          {type === 'error' && (
+            <Image
+              src='/images/progress/0.png'
+              alt='errorAlert'
+              width={100}
+              height={100}
+              className='h-12 w-16'
+              draggable={false}
+            />
+          )}
+          {type === 'info' && (
+            <Image
+              src='/images/progress/30.png'
+              alt='infoAlert'
+              width={100}
+              height={100}
+              className='h-12 w-16'
+              draggable={false}
+            />
+          )}
+          {type === 'success' && (
+            <Image
+              src='/images/progress/100.png'
+              alt='successAlert'
+              width={100}
+              height={100}
+              className='h-12 w-16'
+              draggable={false}
+            />
+          )}
+        </div>
+        <div className='w-80 rounded-lg bg-white px-6 pb-5 pt-3 shadow-lg'>
+          <div className='flex flex-col items-center justify-center break-keep text-center'>
+            <div className='animate-fadeInOnce pt-2'>
+              {type === 'error' && <CircleX size={52} className='text-error' />}
+              {type === 'info' && <Info size={52} className='text-secondary' />}
+              {type === 'success' && (
+                <CircleCheckBig size={52} className='text-[#52C41A]' />
+              )}
+              {type === 'confirm' && (
+                <CircleAlert size={52} className='text-caption' />
+              )}
+            </div>
+            <Title as='h2' textColor='main' size='28px-semibold'>
+              {title}
+            </Title>
+            <Text align='center' textColor='sub' size='16px-medium'>
+              {message}
+            </Text>
+          </div>
 
-          <div className='flex justify-center space-x-2'>
-            {type === 'confirm' && <Button onClick={handleCancel}>취소</Button>}
-            <Button size='small' onClick={handleConfirm}>
-              {type === 'confirm' ? '확인' : '닫기'}
+          <div className='flex justify-center space-x-2 pt-4'>
+            <Button
+              size='small'
+              variant='default'
+              onClick={handleConfirm}
+              disabled={isLoading}
+            >
+              {isLoading ? '로딩중...' : type === 'confirm' ? '확인' : '닫기'}
             </Button>
+            {type === 'confirm' && (
+              <Button
+                size='small'
+                variant='secondary'
+                onClick={handleCancel}
+                disabled={isLoading}
+              >
+                취소
+              </Button>
+            )}
           </div>
         </div>
       </div>

--- a/src/components/commons/alert.tsx
+++ b/src/components/commons/alert.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useAlertStore } from '@/shared/hooks/use-alert-store';
+import Image from 'next/image';
+import Button from './button';
+
+export const Alert = () => {
+  const { isOpen, type, title, message, onConfirm, onCancel, closeAlert } =
+    useAlertStore();
+
+  if (!isOpen) return null;
+
+  const handleConfirm = () => {
+    onConfirm?.();
+    closeAlert();
+  };
+
+  const handleCancel = () => {
+    onCancel?.();
+    closeAlert();
+  };
+
+  return (
+    <div
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+      }}
+      className='z-100 fixed inset-0 flex items-center justify-center bg-[rgba(0,0,0,0.6)]'
+    >
+      <div className='flex -translate-y-16 flex-col items-center justify-center'>
+        <Image
+          src='/images/progress/30.png'
+          alt='alert'
+          width={100}
+          height={100}
+          className='h-30 w-32'
+        />
+        <div className='w-80 rounded-lg bg-white p-6 shadow-lg'>
+          <h2 className='mb-2 text-xl font-bold'>{title}</h2>
+          <p className='text-gray-600 mb-4'>{message}</p>
+
+          <div className='flex justify-center space-x-2'>
+            {type === 'confirm' && <Button onClick={handleCancel}>취소</Button>}
+            <Button size='small' onClick={handleConfirm}>
+              {type === 'confirm' ? '확인' : '닫기'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/modules/dashboard/components/card-button-drop-down.tsx
+++ b/src/modules/dashboard/components/card-button-drop-down.tsx
@@ -129,7 +129,7 @@ const DeleteModal = ({
         '만다라트의 주인이 아닙니다.',
         '방을 나가시겠습니까?'
       ).then((result) => {
-        if (result.isConfirmed) {
+        if (result) {
           getOutRoom({
             roomId: id,
             userId: user as string,
@@ -144,7 +144,7 @@ const DeleteModal = ({
       '정말 삭제하시겠습니까?',
       '삭제한 내용은 되돌릴 수 없습니다.'
     ).then((result) => {
-      if (result.isConfirmed) {
+      if (result) {
         deleteRoom(id);
         setIsDeleteOpen(false);
         setIsOpen(false);

--- a/src/shared/hooks/use-alert-store.ts
+++ b/src/shared/hooks/use-alert-store.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 import { create } from 'zustand';
 
 type AlertType = 'success' | 'error' | 'info' | 'confirm';

--- a/src/shared/hooks/use-alert-store.ts
+++ b/src/shared/hooks/use-alert-store.ts
@@ -1,0 +1,43 @@
+/* eslint-disable no-unused-vars */
+import { create } from 'zustand';
+
+type AlertType = 'success' | 'error' | 'info' | 'confirm';
+
+type AlertState = {
+  isOpen: boolean;
+  type: AlertType;
+  title: string;
+  message: string;
+  onConfirm?: () => void;
+  onCancel?: () => void;
+  openAlert: (
+    type: AlertType,
+    title: string,
+    message?: string,
+    onConfirm?: () => void,
+    onCancel?: () => void
+  ) => void;
+  closeAlert: () => void;
+};
+
+/**
+ * @isOpen  - 알람이 열려 있는지 여부
+ * @type 알람 타입 (success, error, info, confirm)
+ * @title 알람 제목
+ * @message 알람 메세지 내용
+ * @onConfirm 확인버튼 누르면 실행되는 콜백 함수
+ * @onCancel 취소버튼 누르면 실행되는 콜백 함수
+ * @openAlert 알람 열기 위해 실행하는 함수 : (type, title, message, onConfirm, onCancel)
+ * @closeAlert 알람 닫기 위해 실행하는 함수
+ */
+export const useAlertStore = create<AlertState>((set) => ({
+  isOpen: false,
+  type: 'info',
+  title: '',
+  message: '',
+  onConfirm: undefined,
+  onCancel: undefined,
+  openAlert: (type, title, message = '', onConfirm, onCancel) =>
+    set({ isOpen: true, type, title, message, onConfirm, onCancel }),
+  closeAlert: () => set({ isOpen: false }),
+}));

--- a/src/shared/hooks/use-alert-store.ts
+++ b/src/shared/hooks/use-alert-store.ts
@@ -8,16 +8,17 @@ type AlertState = {
   type: AlertType;
   title: string;
   message: string;
-  onConfirm?: () => void;
-  onCancel?: () => void;
+  isLoading: boolean;
   openAlert: (
     type: AlertType,
     title: string,
     message?: string,
-    onConfirm?: () => void,
-    onCancel?: () => void
+    promiseResult?: (value: boolean) => void
   ) => void;
   closeAlert: () => void;
+  promiseResolve?: (value: boolean) => void;
+  loadingStart: () => void;
+  loadingEnd: () => void;
 };
 
 /**
@@ -25,9 +26,7 @@ type AlertState = {
  * @type 알람 타입 (success, error, info, confirm)
  * @title 알람 제목
  * @message 알람 메세지 내용
- * @onConfirm 확인버튼 누르면 실행되는 콜백 함수
- * @onCancel 취소버튼 누르면 실행되는 콜백 함수
- * @openAlert 알람 열기 위해 실행하는 함수 : (type, title, message, onConfirm, onCancel)
+ * @openAlert 알람 열기 위해 실행하는 함수 : (type, title, message)
  * @closeAlert 알람 닫기 위해 실행하는 함수
  */
 export const useAlertStore = create<AlertState>((set) => ({
@@ -35,9 +34,23 @@ export const useAlertStore = create<AlertState>((set) => ({
   type: 'info',
   title: '',
   message: '',
-  onConfirm: undefined,
-  onCancel: undefined,
-  openAlert: (type, title, message = '', onConfirm, onCancel) =>
-    set({ isOpen: true, type, title, message, onConfirm, onCancel }),
-  closeAlert: () => set({ isOpen: false }),
+  promiseResolve: undefined,
+  isLoading: false,
+
+  openAlert: (type, title, message = '', promiseResult) =>
+    set({
+      isOpen: true,
+      type,
+      title,
+      message,
+      isLoading: false,
+      promiseResolve: promiseResult,
+    }),
+
+  closeAlert: () =>
+    set({ isOpen: false, promiseResolve: undefined, isLoading: false }),
+
+  loadingStart: () => set({ isLoading: true }),
+
+  loadingEnd: () => set({ isLoading: false }),
 }));

--- a/src/shared/utils/sweet-alert.ts
+++ b/src/shared/utils/sweet-alert.ts
@@ -1,6 +1,12 @@
 import Swal from 'sweetalert2';
+import { useAlertStore } from '../hooks/use-alert-store';
 
 const confirmButtonColor = 'var(--color-beige)';
+
+const getAlertStore = () => useAlertStore.getState();
+
+export const openAlert = (title: string, message = '') =>
+  getAlertStore().openAlert('success', title, message);
 
 export const successAlert = (title: string, message = '') => {
   return Swal.fire({

--- a/src/shared/utils/sweet-alert.ts
+++ b/src/shared/utils/sweet-alert.ts
@@ -1,53 +1,21 @@
-import Swal from 'sweetalert2';
 import { useAlertStore } from '../hooks/use-alert-store';
-
-const confirmButtonColor = 'var(--color-beige)';
 
 const getAlertStore = () => useAlertStore.getState();
 
-export const openAlert = (title: string, message = '') =>
-  getAlertStore().openAlert('success', title, message);
-
 export const successAlert = (title: string, message = '') => {
-  return Swal.fire({
-    icon: 'success',
-    title: title,
-    text: message,
-    heightAuto: false,
-    confirmButtonColor,
-  });
+  getAlertStore().openAlert('success', title, message);
 };
 
 export const errorAlert = (title: string, message = '') => {
-  return Swal.fire({
-    icon: 'error',
-    title: title,
-    text: message,
-    heightAuto: false,
-    confirmButtonColor,
-  });
+  getAlertStore().openAlert('error', title, message);
 };
 
 export const infoAlert = (title: string, message = '') => {
-  return Swal.fire({
-    icon: 'info',
-    title: title,
-    text: message,
-    heightAuto: false,
-    confirmButtonColor,
-  });
+  getAlertStore().openAlert('info', title, message);
 };
 
-export const confirmAlert = (title: string, message = '') => {
-  return Swal.fire({
-    icon: 'warning',
-    title: title,
-    text: message,
-    showCancelButton: true,
-    confirmButtonColor,
-    cancelButtonColor: '#d33',
-    confirmButtonText: '확인',
-    cancelButtonText: '취소',
-    heightAuto: false,
+export const confirmAlert = (title: string, message = ''): Promise<boolean> => {
+  return new Promise((resolve) => {
+    getAlertStore().openAlert('confirm', title, message, resolve);
   });
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,8 +12,12 @@ const config: Config = {
   theme: {
     extend: {
       keyframes: {
-        fadeIn: {
+        fadeInBottom: {
           '0%': { opacity: '0', transform: 'translateY(10px)' },
+          '100%': { opacity: '1', transform: 'translateY(0)' },
+        },
+        fadeInTop: {
+          '0%': { opacity: '0', transform: 'translateY(-10px)' },
           '100%': { opacity: '1', transform: 'translateY(0)' },
         },
         fadeInRight: {
@@ -34,7 +38,8 @@ const config: Config = {
         },
       },
       animation: {
-        fadeInOnce: 'fadeIn 0.5s ease-out',
+        fadeInOnce: 'fadeInBottom 0.5s ease-out',
+        'fade-in-top': 'fadeInTop 0.7s ease-out',
         'fade-in-right': 'fadeInRight 0.4s ease-out',
         'fade-in-left': 'fadeInLeft 0.4s ease-out',
         'fade-out-right': 'fadeOutRight 0.4s ease-in forwards',

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -51,6 +51,7 @@ const config: Config = {
         '8': '8',
         '9': '9',
         '10': '10',
+        '100': '100',
       },
       fontFamily: {
         pretendard: ['var(--font-pretendard)'],


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #218

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

- [x] 커스텀 알람 추가
- [x] 기존 사용성은 sweetalert 쓰던 메서드 그대로 사용하면 됩니다!
- [x] 위에서 페이드 인 되는 애니메이션 추가

---

## 💢 테스트 사항
대시보드에서 사용되는 모든 알람 그대로 사용되는 것 확인.
confirmAlert의 경우 .then으로 받는 인자는 true/false입니다!

---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->
![image](https://github.com/user-attachments/assets/5adf49e7-4e6d-482b-90e8-14db911196c1)
success 알람
![image](https://github.com/user-attachments/assets/887e2553-ad06-4a49-9be9-f835eac6a14f)
confirm 알람

이제부터는 보기 힘든 알람으로 빈 박스로 대체
![image](https://github.com/user-attachments/assets/59e14b14-2fc0-495f-b848-c6094cf1bebc)
error 알람
![image](https://github.com/user-attachments/assets/2fa34485-dafa-4944-9095-c7749aa6aa15)
info알람

---

## 🙏 리뷰어에게 요청사항

없으면 놔두세요.
