### PR TITLE
bugfix:#264 키다운 이벤트를 키업 이벤트로 수정

### DIFF
--- a/src/modules/mandalart/components/mandalart-floating-sheet.tsx
+++ b/src/modules/mandalart/components/mandalart-floating-sheet.tsx
@@ -123,7 +123,7 @@ const MandalartFloatingSheet = () => {
     }
   };
 
-  const handleInputKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  const handleInputKeyUp = (e: KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Enter') {
       inputRef.current?.blur();
     }
@@ -226,7 +226,7 @@ const MandalartFloatingSheet = () => {
               <div className='no-drag'>
                 <Input
                   ref={inputRef}
-                  onKeyDown={handleInputKeyDown}
+                  onKeyUp={handleInputKeyUp}
                   autoFocus
                   maxLength={charLimit}
                   sizes='28px-regular'
@@ -307,7 +307,7 @@ const MandalartFloatingSheet = () => {
                 />
                 <Input
                   ref={inputRef}
-                  onKeyDown={handleInputKeyDown}
+                  onKeyUp={handleInputKeyUp}
                   autoFocus
                   maxLength={charLimit}
                   sizes='28px-regular'


### PR DESCRIPTION
## 🚀 연관된 이슈

<!-- 해당 PR이 해결하는 이슈 번호를 작성해주세요. (예:  #12) -->

이슈 넘버 : #264 

---

## 📌 작업 내용 요약

<!-- 수행한 작업에 대해 간단히 설명해주세요. -->

- [ ] 맥북 + 크롬에서 엔터가 두번 쳐지는 문제 해결

---

## 💢 테스트 사항

---

## 🖼️ 미리보기

<!-- 작업물 스크린샷 혹은 gif를 올려주세요. -->

---

## 🙏 리뷰어에게 요청사항

없으면 놔두세요.
